### PR TITLE
Integrate uVisor memory management with mbed

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -317,6 +317,8 @@ const osThreadDef_t os_thread_def_##name = \
 /// \return thread ID for reference by other functions or NULL in case of error.
 osThreadId osThreadCreate (const osThreadDef_t *thread_def, void *argument);
 
+osThreadId osThreadContextCreate (const osThreadDef_t *thread_def, void *argument, void *context);
+
 /// Return the thread ID of the current running thread.
 /// \return thread ID for reference by other functions or NULL in case of error.
 osThreadId osThreadGetId (void);

--- a/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
@@ -66,6 +66,7 @@
 #include "rt_Memory.h"
 #include "rt_HAL_CM.h"
 #include "rt_OsEventObserver.h"
+#include "uvisor-lib/uvisor-lib.h"
 
 #include "cmsis_os.h"
 
@@ -466,6 +467,9 @@ osMessageQId svcMessageCreate (const osMessageQDef_t *queue_def, osThreadId thre
 
 /// Initialize the RTOS Kernel for creating objects
 osStatus svcKernelInitialize (void) {
+
+  uvisor_lib_init();
+
 #ifdef __MBED_CMSIS_RTOS_CM
   if (!os_initialized) {
     rt_sys_init();                              // RTX System Initialization

--- a/rtos/rtx/TARGET_CORTEX_M/rt_OsEventObserver.c
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_OsEventObserver.c
@@ -1,0 +1,55 @@
+/*----------------------------------------------------------------------------
+ *      CMSIS-RTOS  -  RTX
+ *----------------------------------------------------------------------------
+ *      Name:    rt_OsEventObserver.c
+ *      Purpose: OS Event Callbacks for CMSIS RTOS
+ *      Rev.:    VX.XX
+ *----------------------------------------------------------------------------
+ *
+ * Copyright (c) 1999-2009 KEIL, 2009-2015 ARM Germany GmbH
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+
+#include "rt_OsEventObserver.h"
+
+/*
+ *  _____ _____  ____  __ _____
+ * |  ___|_ _\ \/ /  \/  | ____|
+ * | |_   | | \  /| |\/| |  _|
+ * |  _|  | | /  \| |  | | |___
+ * |_|   |___/_/\_\_|  |_|_____|
+ *
+ * FIXME:
+ * The osEventObs variable must be in protected memory. If not every box
+ * and box 0 can modify osEventObs to point to any handler to run code
+ * privileged. This issue is tracked at
+ * <https://github.com/ARMmbed/uvisor/issues/235>.
+ */
+const OsEventObserver *osEventObs;
+
+void osRegisterForOsEvents(const OsEventObserver *observer)
+{
+    osEventObs = observer;
+}

--- a/rtos/rtx/TARGET_CORTEX_M/rt_OsEventObserver.h
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_OsEventObserver.h
@@ -1,0 +1,62 @@
+/*----------------------------------------------------------------------------
+ *      CMSIS-RTOS  -  RTX
+ *----------------------------------------------------------------------------
+ *      Name:    os_events.h
+ *      Purpose: OS Event Callbacks for CMSIS RTOS
+ *      Rev.:    VX.XX
+ *----------------------------------------------------------------------------
+ *
+ * Copyright (c) 1999-2009 KEIL, 2009-2016 ARM Germany GmbH
+ * All rights reserved.
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *  - Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *  - Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *  - Neither the name of ARM  nor the names of its contributors may be used
+ *    to endorse or promote products derived from this software without
+ *    specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *---------------------------------------------------------------------------*/
+#ifndef _RT_OS_EVENT_OBSERVER_H
+#define _RT_OS_EVENT_OBSERVER_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* TODO The real ARM_DRIVER_VERSION type or something like it should be used.
+*/
+typedef uint32_t ARM_DRIVER_VERSION;
+
+typedef struct {
+    ARM_DRIVER_VERSION version;
+    void (*pre_start)(void);
+    void *(*thread_create)(int thread_id, void *context);
+    void (*thread_destroy)(void *context);
+    void (*thread_switch)(void *context);
+} OsEventObserver;
+extern const OsEventObserver *osEventObs;
+
+void osRegisterForOsEvents(const OsEventObserver *observer);
+
+#ifdef __cplusplus
+};
+#endif
+
+#endif

--- a/rtos/rtx/TARGET_CORTEX_M/rt_Task.c
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_Task.c
@@ -40,6 +40,7 @@
 #include "rt_MemBox.h"
 #include "rt_Robin.h"
 #include "rt_HAL_CM.h"
+#include "rt_OsEventObserver.h"
 
 /*----------------------------------------------------------------------------
  *      Global Variables
@@ -101,6 +102,9 @@ void rt_switch_req (P_TCB p_new) {
   /* Switch to next task (identified by "p_new"). */
   os_tsk.new_tsk   = p_new;
   p_new->state = RUNNING;
+  if (osEventObs && osEventObs->thread_switch) {
+    osEventObs->thread_switch(p_new->context);
+  }
   DBG_TASK_SWITCH(p_new->task_id);
 }
 

--- a/rtos/rtx/TARGET_CORTEX_M/rt_TypeDef.h
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_TypeDef.h
@@ -79,6 +79,7 @@ typedef struct OS_TCB {
 
   /* Task entry point used for uVision debugger                              */
   FUNCP  ptask;                   /* Task entry address                      */
+  void   *context;                /* Pointer to thread context               */
 } *P_TCB;
 #define TCB_STACKF      37        /* 'stack_frame' offset                    */
 #define TCB_TSTACK      44        /* 'tsk_stack' offset                      */

--- a/uvisor/importer/Makefile
+++ b/uvisor/importer/Makefile
@@ -28,6 +28,8 @@ TARGET_PREFIX:=../
 TARGET_SUPPORTED:=$(TARGET_PREFIX)targets/TARGET_UVISOR_SUPPORTED
 TARGET_UNSUPPORTED:=$(TARGET_PREFIX)targets/TARGET_UVISOR_UNSUPPORTED
 TARGET_INC:=$(TARGET_PREFIX)includes/uvisor/api
+TARGET_LIB_SRC:=$(TARGET_PREFIX)source
+TARGET_LIB_INC:=$(TARGET_PREFIX)includes/uvisor-lib
 
 # uVisor source directory - hidden from mbed via TARGET_IGNORE
 UVISOR_GIT_URL:=https://github.com/ARMmbed/uvisor
@@ -60,10 +62,17 @@ rsync:
 	rm -rf $(TARGET_INC)
 	mkdir -p $(TARGET_INC)
 	rsync -a --delete $(UVISOR_API)/inc $(TARGET_INC)
+	rsync -a --delete $(UVISOR_API)/rtx/inc/ $(TARGET_LIB_INC)/rtx
 	#
 	# Copying uVisor unsupported sources to unsupported target source...
 	mkdir -p $(TARGET_UNSUPPORTED)
 	cp $(UVISOR_API)/src/unsupported.c $(TARGET_UNSUPPORTED)/
+	#
+	# Copying uVisor shared sources to mbed source...
+	rm -rf $(TARGET_LIB_SRC)
+	mkdir -p $(TARGET_LIB_SRC)
+	cp $(UVISOR_DIR)/core/system/src/page_allocator.c $(TARGET_LIB_SRC)/page_allocator.c_inc
+	rsync -a --delete $(UVISOR_API)/rtx/src/ $(TARGET_LIB_SRC)/rtx
 	#
 	# Copying licenses
 	cp $(UVISOR_DIR)/LICENSE* $(TARGET_SUPPORTED)

--- a/uvisor/includes/uvisor-lib/uvisor-lib.h
+++ b/uvisor/includes/uvisor-lib/uvisor-lib.h
@@ -35,5 +35,8 @@
 
 /* The uVisor API main header file will use the above definitions. */
 #include "uvisor/api/inc/uvisor-lib.h"
+#include "uvisor-lib/rtx/process_malloc.h"
+#include "uvisor-lib/rtx/rtx_box_index.h"
+#include "uvisor-lib/rtx/secure_allocator.h"
 
 #endif /* __UVISOR_LIB_UVISOR_LIB_H__ */


### PR DESCRIPTION
Not all relevant uVisor code has been added to use this, but this PR isn't dependent on any code in uVisor. This means that unsupported targets don't yet have the defragmentation benefits of multiple allocators per thread until this goes in https://github.com/Patater/uvisor/commit/afb8c950d3ef927fa20cf0ad3bc8a125e5952b2c

After this goes in, we still need to get some changes into the ARMmbed/mbed-os repository to do things like delete the uvisor-mbed-lib.lib file, update mbed.lib to point at an mbedmicro/mbed that contains uvisor, and to wrap malloc. I've made a preliminary branch for that at https://github.com/Patater/mbed-os/tree/malloc-micro-demo

To see a working demo of this, use `mbed import mbed import https://github.com/Patater/example-mbed-mallocator`.

@AlessandroA @niklas-arm @meriac