### PR TITLE
fixup! Add OsEventObserver

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/rt_OsEventObserver.h
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_OsEventObserver.h
@@ -40,12 +40,8 @@
 extern "C" {
 #endif
 
-/* TODO The real ARM_DRIVER_VERSION type or something like it should be used.
-*/
-typedef uint32_t ARM_DRIVER_VERSION;
-
 typedef struct {
-    ARM_DRIVER_VERSION version;
+    uint32_t version;
     void (*pre_start)(void);
     void *(*thread_create)(int thread_id, void *context);
     void (*thread_destroy)(void *context);


### PR DESCRIPTION
Remove ARM_DRIVER_VERSION typedef. This makes the rtx file out of sync with the uVisor copy, but there is still binary compatibility between the structs. We should update the uVisor copy after the rtx one is final.

@AlessandroA @meriac @niklas-arm