### PR TITLE
fixup! Wrap software_init_hook

### DIFF
--- a/rtos/rtx/TARGET_ARM7/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_ARM7/RTX_CM_lib.h
@@ -339,7 +339,7 @@ void pre_main(void) {
     main(0, NULL);
 }
 
-__attribute__((naked)) void software_init_hook (void) {
+__attribute__((naked)) void software_init_hook_rtos (void) {
   __asm (
     ".syntax unified\n"
     ".thumb\n"

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
@@ -447,7 +447,7 @@ __asm void __rt_entry (void) {
 
 #elif defined (__GNUC__)
 
-__attribute__((naked)) void software_init_hook (void) {
+__attribute__((naked)) void software_init_hook_rtos (void) {
   __asm (
     ".syntax unified\n"
     ".arm\n"

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -655,7 +655,7 @@ void pre_main(void) {
     main(0, NULL);
 }
 
-__attribute__((naked)) void software_init_hook (void) {
+__attribute__((naked)) void software_init_hook_rtos (void) {
   __asm (
     "bl   osKernelInitialize\n"
 #ifdef __MBED_CMSIS_RTOS_CM


### PR DESCRIPTION
The rtos changes originally part of this commit got lost. Re-add them here with this fixup.

Tested with mbed Classic, both with and without RTOS
Tested with mbed-os

**XXX When merging**, please update the git commit message descriptions to the following commits. Their commit messages got deleted on accident.
- "Wrap software_init_hook"
```
Wrap software_init_hook so that it can be used or extended from outside the
RTOS. This is desirable so that code can be added to the software_init_hook
without making the RTOS depend on new features or libraries.
```

- "Initialize uvisor-lib"
```
uvisor-lib has an init function that must be called before the RTOS kernel
is initialized. Call uvisor_lib_init from software_init_hook to accomplish
this.
```

@AlessandroA @meriac @niklas-arm