### PR TITLE
Explicitly set the start address of hardcoded uVisor sections

### DIFF
--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -90,7 +90,11 @@ SECTIONS
   } > m_flash_config
 
   /* The program code and other data goes into internal flash */
-  .text :
+  /* Note: The uVisor expects this section at a fixed location, as specified by
+   * the porting process configuration parameter: FLASH_OFFSET. */
+  __UVISOR_TEXT_OFFSET = 0x410;
+  __UVISOR_TEXT_START = ORIGIN(m_interrupts) + __UVISOR_TEXT_OFFSET;
+  .text __UVISOR_TEXT_START :
   {
     /* uVisor code and data */
     . = ALIGN(4);

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -204,7 +204,7 @@ SECTIONS
   __UVISOR_BSS_START = ORIGIN(m_data) + __UVISOR_SRAM_OFFSET;
   ASSERT(__interrupts_ram_end__ <= __UVISOR_BSS_START,
          "The ISR relocation region overlaps with the uVisor BSS section.")
-  .uvisor.bss (NOLOAD):
+  .uvisor.bss __UVISOR_BSS_START (NOLOAD):
   {
     . = ALIGN(32);
     __uvisor_bss_start = .;


### PR DESCRIPTION
Currently we have 2 sections in uVisor that require a hard-coded start address: `uvisor.bss` and `uvisor.main`.

Their position is set by the config-time symbols `SRAM_OFFSET` and `FLAS_OFFSET` respectively.

This PR makes sure that those sections end up at the required address in the host OS.

In particular, a bug if fixed for which the .text section was being moved around in a non-deterministic way due to the alignment inheritance rules in GCC (see the `K64F: Explicitly set the start of .text` commit message for more details).

@meriac @niklas-arm @patater