### PR TITLE
Add configuration file for when FEATURE_UVISOR is set

### DIFF
--- a/features/FEATURE_UVISOR/mbed_lib.json
+++ b/features/FEATURE_UVISOR/mbed_lib.json
@@ -1,0 +1,4 @@
+{
+    "name": "uvisor-lib",
+    "macros": ["CMSIS_NVIC_VIRTUAL", "CMSIS_VECTAB_VIRTUAL"]
+}


### PR DESCRIPTION
The configuration file at the moment only contains the CMSIS NVIC
virtualization macros. When FEATURE_UVISOR is set, we turn on CMSIS NVIC
virtualization automatically.

This removes the need for users to specify the macros themselves.

If UVISOR_SUPPORTED is set as well, the NVIC macros are turned into vIRQ
ones, otherwise they stay NVIC as usual, thanks to the fallback
implementation provided by `unsupported.h`.

@meriac @niklas-arm @patater