### PR TITLE
uVisor: Copy the quick-start guide to the FEATURE_UVISOR folder

### DIFF
--- a/features/FEATURE_UVISOR/importer/Makefile
+++ b/features/FEATURE_UVISOR/importer/Makefile
@@ -77,6 +77,9 @@ rsync:
 	#
 	# Copying licenses
 	cp $(UVISOR_DIR)/LICENSE* $(TARGET_SUPPORTED)
+	#
+	# Copying documentation...
+	cp $(UVISOR_DIR)/docs/QUICKSTART.md $(TARGET_PREFIX)/README.md
 
 TARGET_M%: $(TARGET_SUPPORTED)/*/*/*_m%_*.a
 	@printf "#\n# Copying $@ files...\n"


### PR DESCRIPTION
**Note**: Currently the file `QUICKSTART.md` lives in the `dev` branch in uVisor, while this repo tracks `unstable`.

Since we want to merge `unstable` into `dev`, we should first merge all relevant PRs in uVisor and then track `dev` here. This PR can then be merged as-is.

Depends on ARMmbed/uvisor#272.

@meriac 